### PR TITLE
Add CJK support.

### DIFF
--- a/lib/reader2.js
+++ b/lib/reader2.js
@@ -236,18 +236,44 @@ Reader.prototype.readString = function(data) {
 
     var code = this.reader.nextUInt8();
     if (code >= 0 && code < 32) {
-        return this.reader.nextString(code);
+        return this._nextString(code);
     } else if (code >= 0x30 && code <= 0x33) {
         this.reader.move(-1);
         var len = this.reader.nextUInt16BE() - 0x3000;
-        return this.reader.nextString(len);
+        return this._nextString(len);
     } else if (code === 0x53) {
         var len = this.reader.nextUInt16BE();
-        return this.reader.nextString(len);
+        return this._nextString(len);
     } else if (code === 0x52) {
         var len = this.reader.nextUInt16BE();
-        return this.reader.nextString(len) + this.readString();
+        return this._nextString(len) + this.readString();
     }
+};
+
+Reader.prototype._nextString = function(length, encoding) {
+    
+    assert(length >= 0, 'Length must be no negative');
+   
+    var tbuf = [];
+    while(length > 0) {
+   
+        var t = this.reader.nextUInt8();
+        tbuf.push(t);
+        if(t >= 0xC2 && t < 0xE0) {
+            tbuf.push(this.reader.nextUInt8());
+        }
+        else if(t >= 0xE0 && t < 0xF0) {
+            tbuf.push(this.reader.nextUInt8()); 
+            tbuf.push(this.reader.nextUInt8());   
+        }
+        else if(t >= 0xF0 && t < 0xF5) {
+            tbuf.push(this.reader.nextUInt8());
+            tbuf.push(this.reader.nextUInt8()); 
+            tbuf.push(this.reader.nextUInt8()); 
+        }
+        length--;
+    }
+    return new Buffer(tbuf).toString(encoding);
 };
 
 Reader.prototype.readLong = function(data) {


### PR DESCRIPTION
reader2.readString can't read CJK(Chinese , Japanese, Korean. 2~3 byte character) string.

Try 粗麻布,해시안,ヘッセ for reply.

I guess, buffer-reader's readString can't handle variable length character.
readString's argument 'length' is byte by your design.

readStringZero (from buffer-reader v0.1.0) can't solve node-hessian CJK problem either.

So I added some code for me.

Request is just proposal. :) 
