### PR TITLE
Corrected the way basic authtication parameters are supplied to HttpClient

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -48,11 +48,7 @@ Proxy.prototype.invoke = function(method, args, callback) {
         };
 
     if (this.username) {
-        options.auth = {
-            user: this.username,
-            pass: this.password,
-            sendImmediately: true
-        };
+        options.auth = this.username + ':' + this.password;
     }
 
     var req = require(this.protocol).request(options, function(res) {


### PR DESCRIPTION
Fix for issue #11: HTTP authentication fails with TypeError 