### PR TITLE
Corrected handling of double values with up to three decimal places

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -48,7 +48,9 @@ Proxy.prototype.invoke = function(method, args, callback) {
         };
 
     if (this.username) {
-        options.auth = this.username + ':' + this.password;
+        // Use iso-8859-1 character encoding for basic authentication parameters
+        options.headers['Authorization'] = 'Basic '
+            + Buffer.from(this.username + ':' + this.password, 'latin1').toString('base64');
     }
 
     var req = require(this.protocol).request(options, function(res) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -48,11 +48,7 @@ Proxy.prototype.invoke = function(method, args, callback) {
         };
 
     if (this.username) {
-        options.auth = {
-            user: this.username,
-            pass: this.password,
-            sendImmediately: true
-        };
+        options.auth = this.username + ':' + this.password;
     }
 
     var req = require(this.protocol).request(options, function(res) {

--- a/lib/reader2.js
+++ b/lib/reader2.js
@@ -229,6 +229,33 @@ Reader.prototype.readClassDef = function(data) {
     }
 };
 
+Reader.prototype.readUTF8String = function(len) {
+
+    if (len === 0)
+        return "";
+
+    var startPos = this.reader.tell(), byteLength;
+
+    while (len--) {
+        var head = this.reader.nextUInt8();
+        if (head < 0x80) {
+            continue;
+        } else if ((head & 0xe0) === 0xc0) {
+            this.reader.move(1);
+        } else if ((head & 0xf0) === 0xe0) {
+            this.reader.move(2);
+        } else if ((head & 0xf8) === 0xf0) {
+            this.reader.move(3);
+        } else {
+            throw new Error("String is not in valid UTF-8 format");
+        }
+    }
+
+    byteLength = this.reader.tell() - startPos;
+    this.reader.seek(startPos);
+
+    return this.reader.nextString(byteLength, 'utf8');
+}
 
 Reader.prototype.readString = function(data) {
     if (data)
@@ -236,17 +263,17 @@ Reader.prototype.readString = function(data) {
 
     var code = this.reader.nextUInt8();
     if (code >= 0 && code < 32) {
-        return this.reader.nextString(code);
+        return this.readUTF8String(code);
     } else if (code >= 0x30 && code <= 0x33) {
         this.reader.move(-1);
         var len = this.reader.nextUInt16BE() - 0x3000;
-        return this.reader.nextString(len);
+        return this.readUTF8String(len);
     } else if (code === 0x53) {
         var len = this.reader.nextUInt16BE();
-        return this.reader.nextString(len);
+        return this.readUTF8String(len);
     } else if (code === 0x52) {
         var len = this.reader.nextUInt16BE();
-        return this.reader.nextString(len) + this.readString();
+        return this.readUTF8String(len) + this.readString();
     }
 };
 

--- a/lib/reader2.js
+++ b/lib/reader2.js
@@ -389,9 +389,11 @@ Reader.prototype.readDouble = function(data) {
         return this.reader.nextInt8();
     else if (code === 0x5e)
         return this.reader.nextInt16BE();
-    else if (code === 0x5f)
-        return this.reader.nextFloatBE();
-    else if (code === 0x44) {
+    else if (code === 0x5f) {
+        // While the specification suggests reading a FloatBE here,
+        // this is the way how it's handled by the Java implementation
+        return this.reader.nextInt32BE() * 0.001;
+    } else if (code === 0x44) {
         return this.reader.nextDoubleBE();
     }
 };

--- a/lib/writer2.js
+++ b/lib/writer2.js
@@ -366,11 +366,11 @@ Writer.prototype.writeList = function(data) {
 };
 
 Writer.prototype.writeType = function(data) {
-    this.writeString(data);
     if (this.typeRefs.hasOwnProperty(data)) {
         this.writeInt(this.typeRefs[data]);
     } else {
         this.typeRefs[data] = Object.keys(this.typeRefs).length;
+        this.writeString(data);
     }
     return this;
 };


### PR DESCRIPTION
Deserialization of double values with code 0x5f was correct according to the Hessian specification, but the Java implementation does things differently. As I view it, this is a bug in the specification and the Java way should be used in all implementations.